### PR TITLE
feat: 회원리스트 조회 기능(검색필터 적용) Mapper 추가

### DIFF
--- a/src/main/java/com/ssg/meowcoffee/domain/UserStatus.java
+++ b/src/main/java/com/ssg/meowcoffee/domain/UserStatus.java
@@ -11,7 +11,8 @@ public enum UserStatus implements UserEnum {
     APPROVAL("APPROVAL", "승인완료"),
     WAITING_APPROVAL("WAITING_APPROVAL", "승인대기"),
     DEACTIVATED("DEACTIVATED", "휴면상태"),
-    WAITING_DEACTIVATED("WAITING_DEACTIVATE", "휴면대기");
+    WAITING_DEACTIVATED("WAITING_DEACTIVATE", "휴면대기"),
+    ALL("ALL", "전체");   // 검색 시 필터링용
 
     private final String statusName;
     private final String statusValue;

--- a/src/main/java/com/ssg/meowcoffee/dto/UserCriteria.java
+++ b/src/main/java/com/ssg/meowcoffee/dto/UserCriteria.java
@@ -1,67 +1,85 @@
 package com.ssg.meowcoffee.dto;
 
 import com.ssg.meowcoffee.domain.UserRole;
+import com.ssg.meowcoffee.domain.UserStatus;
 import java.time.LocalDate;
 import java.util.Arrays;
 import javax.validation.constraints.Future;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
-import lombok.AllArgsConstructor;
+import javax.validation.constraints.Positive;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.Data;
 import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
 
-@Getter
-@Setter
+@Data
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class UserCriteria extends Criteria {
+public class UserCriteria {
 
     @Builder.Default
     @Min(value = 1)
+    @Positive
     private int pageNum = 1;
 
+    @Setter
     @Builder.Default
     @Min(value = 10)
     @Max(value = 30)
+    @Positive
     private int amount = 10;
 
-    // 회원권한별 필터링 옵션
+    // 회원유형별 필터링 옵션
     private UserRole roleType;
-    // 키워드 검색 시 필터링 옵션
-    private String keywordFilter;
-    // 특정 기간 내 가입/로그인 여부 필터링 옵션
+    // 회원상태별 필터링 옵션
+    private UserStatus statusType;
+
+    // 키워드 검색 시 필터링 옵션 - null, 이름(N), 아이디(I), 이름+아이디(NI)
+    private String[] types;
+    private String typeString;
+
+    // 특정 기간 내 미선택/가입(reg)/로그인(login) 여부 필터링 옵션
     private String periodFilter;
 
     // 설정한 기간
+    @DateTimeFormat(iso = ISO.DATE)
     private LocalDate from;
 
     @Future
+    @DateTimeFormat(iso = ISO.DATE)
     private LocalDate to;
 
     private String keyword;
 
-    public void setRoleType(String searchOption) {
-        this.roleType = Arrays.stream(UserRole.values())
-                    .filter(userRole -> searchOption.equals(userRole.getRoleName()))
-                    .findAny()
-                    .orElse(UserRole.ALL);
-    }
-
-    @Override
+    // 페이지네이션 관련
     public void setPageNum(int pageNum) {
         this.pageNum = Math.max(pageNum, 1);
     }
 
-    @Override
-    public void setAmount(int amount) {
-        this.amount = amount;
-    }
-
-    @Override
     public int getSkip() {
         return (this.pageNum - 1) * this.amount;
+    }
+
+    // 회원권한, 회원상태별 필터링
+    public void setRoleType(String searchOption) {
+        this.roleType = Arrays.stream(UserRole.values())
+                .filter(userRole -> searchOption.equals(userRole.getRoleName()))
+                .findAny()
+                .orElse(UserRole.ALL);
+    }
+
+    public void setStatusType(String searchOption) {
+        this.statusType = Arrays.stream(UserStatus.values())
+                .filter(userStatus -> searchOption.equals(userStatus.getName()))
+                .findAny()
+                .orElse(UserStatus.ALL);
+    }
+
+    public void setTypes(String[] types) {
+        this.types = types;
+        if (this.types.length > 0) {
+            this.typeString = String.join("", this.types);
+        }
     }
 }

--- a/src/main/java/com/ssg/meowcoffee/dto/UserPageDTO.java
+++ b/src/main/java/com/ssg/meowcoffee/dto/UserPageDTO.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 // 회원관리 기능용 페이지 DTO입니다.
 @Getter
 @ToString
-public class UserPageDTO<E> extends PageDTO {
+public class UserPageDTO<E> {
 
     private int page;
     private int amount;
@@ -21,7 +21,6 @@ public class UserPageDTO<E> extends PageDTO {
 
     @Builder
     public UserPageDTO(UserCriteria cri, List<E> dtoList, int total) {
-        super(cri, total);
         this.page = cri.getPageNum();
         this.amount = cri.getAmount();
         this.total = total;

--- a/src/main/resources/mappers/MemberMapper.xml
+++ b/src/main/resources/mappers/MemberMapper.xml
@@ -19,18 +19,71 @@
     <result column="userLastLogin" property="userLastLogin"/>
 
     <!--  회원 관련 테이블/뷰의 enum 타입을 VO에서 저장할 경우에는 반드시 지정한 TypeHandler를 명시해주세요.  -->
-    <result column="userRole" property="userRole" typeHandler="com.ssg.meowcoffee.util.CustomEnumTypeHandler"/>
-    <result column="userStatus" property="userStatus" typeHandler="com.ssg.meowcoffee.util.CustomEnumTypeHandler"/>
+    <result column="userRole" property="userRole" typeHandler="CustomEnumTypeHandler"/>
+    <result column="userStatus" property="userStatus" typeHandler="CustomEnumTypeHandler"/>
     <result column="vehicleId" property="vehicleId"/>
   </resultMap>
 
+  <!-- 검색필터 조건 -->
+  <sql id="search">
+    <where>
+      <!--  회원권한 필터링  -->
+      <if test="cri.roleType != null and cri.roleType.name != 'ALL'">
+        and userRole = #{cri.roleType}
+      </if>
+      <!--  회원상태 필터링  -->
+      <if test="cri.statusType != null and cri.statusType.name != 'ALL'">
+        and userStatus = #{cri.statusType}
+      </if>
+
+      <!--  이름/아이디 키워드 검색  -->
+      <if test="cri.types != null and cri.keyword != null">
+        <foreach collection="cri.types" item="type" open="(" separator="OR" close=")">
+          <choose>
+            <when test="cri.type.equals('N')">
+              and userName like concat('%', #{keyword}, '%')
+            </when>
+            <when test="cri.type.equals('I')">
+              and userId like concat('%', #{keyword}, '%')
+            </when>
+          </choose>
+        </foreach>
+      </if>
+
+      <!--  기간별 필터링  -->
+      <if test="cri.from != null">
+        <choose>
+          <when test="cri.periodFilter == 'reg'">
+            and userJoinDate >= #{cri.from}
+          </when>
+          <otherwise>
+            and userLastLogin >= #{cri.from}
+          </otherwise>
+        </choose>
+      </if>
+      <if test="cri.to != null">
+        <choose>
+          <when test="cri.periodFilter == 'reg'">
+            and userJoinDate <![CDATA[ <= ]]> #{cri.to}
+          </when>
+          <otherwise>
+            and userLastLogin <![CDATA[ <= ]]> #{cri.to}
+          </otherwise>
+        </choose>
+      </if>
+    </where>
+  </sql>
+
+
   <select id="getCount" resultType="int">
     select count(userId) from users
+    <include refid="search"/>
   </select>
 
   <!-- resultMap Enum 매핑 테스트용 조회 쿼리 -->
   <select id="selectUsers" resultMap="userResultMap">
     select * from users
+    <include refid="search"/>
     limit #{cri.skip}, #{cri.amount}
   </select>
 

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -7,5 +7,6 @@
     <!--  MyBatis ResultType 패키지 경로 설정  -->
     <typeAliases>
         <package name="com.ssg.meowcoffee.domain"/>
+        <package name="com.ssg.meowcoffee.util"/>
     </typeAliases>
 </configuration>

--- a/src/test/java/com/ssg/meowcoffee/mapper/MemberMapperTests.java
+++ b/src/test/java/com/ssg/meowcoffee/mapper/MemberMapperTests.java
@@ -4,10 +4,10 @@ import com.ssg.meowcoffee.domain.ManagerVO;
 import com.ssg.meowcoffee.domain.UserRole;
 import com.ssg.meowcoffee.domain.UserStatus;
 import com.ssg.meowcoffee.domain.UserVO;
-import com.ssg.meowcoffee.dto.Criteria;
 import com.ssg.meowcoffee.dto.UserCriteria;
 import com.ssg.meowcoffee.dto.UserInfoDTO;
 import com.ssg.meowcoffee.dto.UserStatusDTO;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.Assertions;
@@ -27,11 +27,13 @@ public class MemberMapperTests {
     private MemberMapper memberMapper;
 
     @Test
-    @DisplayName("페이지네이션 적용된 리스트 조회")
-    public void testSelectAll() {
+    @DisplayName("페이지네이션 및 검색필터 적용된 회원 리스트 조회")
+    public void testSelectAllByFilter() {
         UserCriteria criteria = UserCriteria.builder()
                 .pageNum(1)
                 .amount(10)
+                .from(LocalDate.parse("2025-06-01"))
+                .to(LocalDate.parse("2025-11-01"))
                 .build();
         List<UserVO> list = memberMapper.selectUsers(criteria);
         list.forEach(log::info);


### PR DESCRIPTION
관리자 전용 회원관리 기능 중 검색필터를 적용한 회원리스트 조회 기능에 관한 Mapper 구현 및 테스트 완료했습니다.

적용한 검색필터는 아래와 같습니다.
* 지정한 회원권한/회원상태로 필터링
* 이름/아이디/이름+아이디에 관한 키워드 검색
* 특정 날짜 이전/이후 또는 특정 기간 내 신규 가입자 or 마지막 접속자 필터링(휴면회원 전환 기능과 연계 가능)