### PR TITLE
feat: 로그인, 회원가입 관련 mapper 추가

### DIFF
--- a/src/main/java/com/ssg/meowcoffee/dto/FindIDDTO.java
+++ b/src/main/java/com/ssg/meowcoffee/dto/FindIDDTO.java
@@ -1,0 +1,16 @@
+package com.ssg.meowcoffee.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FindIDDTO {
+
+    private String targetRole;
+    private String userCode;
+    private String userName;
+    private String userEmail;
+}

--- a/src/main/java/com/ssg/meowcoffee/dto/FindIDResultDTO.java
+++ b/src/main/java/com/ssg/meowcoffee/dto/FindIDResultDTO.java
@@ -1,0 +1,24 @@
+package com.ssg.meowcoffee.dto;
+
+import com.ssg.meowcoffee.domain.UserRole;
+import lombok.*;
+
+import java.util.Arrays;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FindIDResultDTO {
+
+    private UserRole userRole;
+    private String userId;
+
+    public void setUserRole(String userRole) {
+        this.userRole = Arrays.stream(UserRole.values())
+                .filter(role -> role.getRoleName().equals(userRole))
+                .findAny()
+                .get();
+    }
+}

--- a/src/main/java/com/ssg/meowcoffee/mapper/MemberMapper.java
+++ b/src/main/java/com/ssg/meowcoffee/mapper/MemberMapper.java
@@ -4,9 +4,8 @@ import com.ssg.meowcoffee.domain.CompanyVO;
 import com.ssg.meowcoffee.domain.DeliverymanVO;
 import com.ssg.meowcoffee.domain.ManagerVO;
 import com.ssg.meowcoffee.domain.UserVO;
-import com.ssg.meowcoffee.dto.UserCriteria;
-import com.ssg.meowcoffee.dto.UserInfoUpdateDTO;
-import com.ssg.meowcoffee.dto.UserStatUpdateDTO;
+import com.ssg.meowcoffee.dto.*;
+
 import java.util.List;
 import org.apache.ibatis.annotations.Param;
 
@@ -26,9 +25,15 @@ public interface MemberMapper {
 
     int getCount(@Param("cri") UserCriteria criteria);
 
-    int updateUser(@Param("userInfo") UserInfoUpdateDTO userInfoUpdateDTO);                // 회원정보 변경
+    int insertUser(@Param("userInfo") UserDetailDTO userDetailDTO);
+
+    // 회원정보 변경
+    // 변경된 비밀번호는 서비스 계층에서 반드시 암호화되어 전달되어야 하므로 기존의 updateUser() 메서드를 재사용
+    int updateUser(@Param("userInfo") UserInfoUpdateDTO userInfoUpdateDTO);
     int updateUserStatus(@Param("userStat") UserStatUpdateDTO userStatUpdateDTO);      // 회원상태 변경(총관리자 전용)
 
     int deleteUser(@Param("currentId") String currentId);         // 휴면회원 전환 신청
     int deleteUserByAdmin(@Param("targetId") String targetId);   // 휴면회원 전환(총관리자 전용)
+
+    FindIDResultDTO findUserId(@Param("userInfo") FindIDDTO findIDDTO);
 }

--- a/src/main/resources/db_sql/member_create_table_view.sql
+++ b/src/main/resources/db_sql/member_create_table_view.sql
@@ -23,6 +23,8 @@ CREATE TABLE users (
 
 ALTER TABLE users ADD CONSTRAINT PK_USERS PRIMARY KEY (userId);
 
+# userStatus의 초기값 지정
+ALTER TABLE users ALTER COLUMN userStatus SET DEFAULT 'WAITING_APPROVAL';
 
 # 원본 테이블인 users를 먼저 생성해야 관리자 뷰를 생성할 수 있습니다.
 # erdcloud에서 생성된 sql문의 create table managers ~ 대신 아래의 create view문을 사용

--- a/src/main/resources/mappers/MemberMapper.xml
+++ b/src/main/resources/mappers/MemberMapper.xml
@@ -113,6 +113,44 @@
     select * from deliverymen where delivId = #{userId}
   </select>
 
+  <select id="findUserId" resultType="com.ssg.meowcoffee.dto.FindIDResultDTO">
+    select userId, userRole from users
+    <choose>
+      <when test="#{userInfo.targetRole == 'COMPANY'}">
+        where userCode = (
+          select comCode
+          from companies
+          where comCode = #{userInfo.userCode} and comEmail = #{userInfo.userEmail}
+        )
+      </when>
+      <when test="#{userInfo.targetRole == 'MANAGER' or userInfo.targetRole == 'ADMIN'}">
+        where userCode = (
+          select managerCode
+          from managers
+          where managerName = #{userInfo.userName} and managerEmail = #{userInfo.userEmail}
+        )
+      </when>
+      <otherwise>
+        where userCode = (
+          select delivCode
+          from deliverymen
+          where delivCode = #{userInfo.userCode} and comEmail = #{userInfo.userEmail}
+        )
+      </otherwise>
+    </choose>
+  </select>
+
+  <insert id="insertUser" >
+    insert into
+    users (
+      userId, userPwd, userCompanyName, userName, userPhone,
+      userEmail, userCode, userRoadAddr, userDetailAddr, userRole
+    )
+    values(
+      #{userInfo.userId}, #{userInfo.userPwd}, #{userInfo.userCompanyName}, #{userInfo.userName}, #{userInfo.userPhone},
+      #{userInfo.userEmail}, #{userInfo.userCode}, #{userInfo.userRoadAddr}, #{userInfo.userDetailAddr}, #{userInfo.userRole}
+    )
+  </insert>
 
   <update id="updateUser">
     update users
@@ -132,6 +170,9 @@
   <update id="updateUserStatus">
     update users
     set userStatus = #{userStat.userStatus}
+    <if test="#{userStat.userStatus == 'APPROVAL'}">
+      , userJoinDate = now()
+    </if>
     where userId = #{userStat.userId}
   </update>
 

--- a/src/test/java/com/ssg/meowcoffee/mapper/MemberMapperTests.java
+++ b/src/test/java/com/ssg/meowcoffee/mapper/MemberMapperTests.java
@@ -6,9 +6,8 @@ import com.ssg.meowcoffee.domain.ManagerVO;
 import com.ssg.meowcoffee.domain.UserRole;
 import com.ssg.meowcoffee.domain.UserStatus;
 import com.ssg.meowcoffee.domain.UserVO;
-import com.ssg.meowcoffee.dto.UserCriteria;
-import com.ssg.meowcoffee.dto.UserInfoUpdateDTO;
-import com.ssg.meowcoffee.dto.UserStatUpdateDTO;
+import com.ssg.meowcoffee.dto.*;
+
 import java.time.LocalDate;
 import java.util.List;
 import lombok.extern.log4j.Log4j2;
@@ -86,6 +85,41 @@ public class MemberMapperTests {
         DeliverymanVO deliverymanVO = memberMapper.selectDeliverymenById(userId);
         log.info(deliverymanVO);
         Assertions.assertEquals(userId, deliverymanVO.getDelivId());
+    }
+
+    @Test
+    @DisplayName("입력한 이메일, 사업자등록번호에 해당하는 거래처 찾기")
+    public void testFindUserId() {
+        String userCode = "123-45-67890";
+        String userEmail = "ceo1@meowcoffee.com";
+        FindIDDTO findIDDTO = FindIDDTO.builder()
+                .targetRole(UserRole.COMPANY.getRoleName())
+                .userCode(userCode)
+                .userEmail(userEmail)
+                .build();
+
+        FindIDResultDTO found = memberMapper.findUserId(findIDDTO);
+        Assertions.assertEquals("coffeebiz01", found.getUserId());
+        Assertions.assertEquals(UserRole.COMPANY, found.getUserRole());
+    }
+
+    @Test
+    @DisplayName("새로운 거래처 회원 등록")
+    public void testInsertUser() {
+        UserDetailDTO newUser = UserDetailDTO.builder()
+                .userId("company5678")
+                .userPwd("123456")
+                .userCompanyName("이디야")
+                .userName("홍길동")
+                .userPhone("010-2345-6789")
+                .userCode("987-65-43210")
+                .userEmail("company1234@test.com")
+                .userRoadAddr("서울시 강남구 테헤란로 46")
+                .userDetailAddr("1층")
+                .userRole(UserRole.COMPANY)
+                .build();
+        int affected = memberMapper.insertUser(newUser);
+        Assertions.assertEquals(1, affected);
     }
 
     @Test


### PR DESCRIPTION
로그인, 회원가입, 아이디 찾기, 비밀번호 변경에 관한 쿼리를 수행하는 mapper를 추가했습니다.

그리고 스프링 시큐리티를 사용한 기본적인 로그인/로그아웃 기능 자체는 이미 구현했지만, 구현한 로그인 기능을 현재 프로젝트에 합치는 과정에서 프로젝트의 xml 설정 파일을 수정해야 하기 때문에, 해당 작업은 추후에 진행해야 할 것 같습니다.