### PR TITLE
fix(stock): 공통 nav바 dropbox 안열리는 문제 해결

### DIFF
--- a/src/main/webapp/WEB-INF/views/includes/_footerHead.jsp
+++ b/src/main/webapp/WEB-INF/views/includes/_footerHead.jsp
@@ -175,9 +175,8 @@
 
 </div>
 <!-- End Custom template --><!-- Core JS Files -->
-<script src="/resources/assets/js/core/jquery-3.7.1.min.js"></script>
 <script src="/resources/assets/js/core/popper.min.js"></script>
-<script src="/resources/assets/js/core/bootstrap.min.js"></script>
+<%--<script src="/resources/assets/js/core/bootstrap.min.js"></script>--%>
 
 <!-- Axios (비동기 HTTP 요청 라이브러리) ★★★ 추가됨 ★★★ -->
 <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>


### PR DESCRIPTION
처음 기본 페이지를 제외한 나머지 구현 페이지에서 headerNav의 dropbox가 안열리는 문제를 수정했습니다. 
footerHead에서 중복된 js script를 제외했습니다.