### PR TITLE
chore(auth): 스프링 시큐리티 관련 주석 추가

### DIFF
--- a/src/main/java/com/ssg/meowcoffee/controller/MainController.java
+++ b/src/main/java/com/ssg/meowcoffee/controller/MainController.java
@@ -16,8 +16,8 @@ import java.util.Iterator;
 public class MainController {
 
     @GetMapping("/")
-    public String home(Model model) {
-        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+    public String home(Authentication authentication, Model model) {
+        String userId = authentication.getName();
         String role = getRole();
         model.addAttribute("userId", userId);
         model.addAttribute("roleType", role);

--- a/src/main/java/com/ssg/meowcoffee/controller/MainController.java
+++ b/src/main/java/com/ssg/meowcoffee/controller/MainController.java
@@ -16,8 +16,8 @@ import java.util.Iterator;
 public class MainController {
 
     @GetMapping("/")
-    public String home(Authentication authentication, Model model) {
-        String userId = authentication.getName();
+    public String home(Model model) {
+        String userId = SecurityContextHolder.getContext().getAuthentication().getName();
         String role = getRole();
         model.addAttribute("userId", userId);
         model.addAttribute("roleType", role);

--- a/src/main/java/com/ssg/meowcoffee/dto/CustomUserDetails.java
+++ b/src/main/java/com/ssg/meowcoffee/dto/CustomUserDetails.java
@@ -22,7 +22,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        // 현재 로그인한 사용자의 보유한 권한을 반환
+        // 현재 로그인한 사용자가 보유한 권한을 반환
         List<GrantedAuthority> collection = new ArrayList<>();
         collection.add(new SimpleGrantedAuthority("ROLE_" + userVO.getUserRole()));
         return collection;

--- a/src/main/java/com/ssg/meowcoffee/dto/CustomUserDetails.java
+++ b/src/main/java/com/ssg/meowcoffee/dto/CustomUserDetails.java
@@ -1,5 +1,6 @@
 package com.ssg.meowcoffee.dto;
 
+import com.ssg.meowcoffee.domain.UserStatus;
 import com.ssg.meowcoffee.domain.UserVO;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 현재 로그인한 사용자의 보유한 권한을 반환
         List<GrantedAuthority> collection = new ArrayList<>();
         collection.add(new SimpleGrantedAuthority("ROLE_" + userVO.getUserRole()));
         return collection;
@@ -28,31 +30,35 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getPassword() {
+        // 현재 로그인한 사용자의 비밀번호를 반환
         return userVO.getUserPwd();
     }
 
     @Override
     public String getUsername() {
+        // 현재 로그인한 사용자의 아이디를 반환
         return userVO.getUserId();
     }
 
+    // 계정 만료, 잠금, 자격 증명 만료 관련 조건을 설정하는 부분
     @Override
-    public boolean isAccountNonExpired() {  // 계정 만료
+    public boolean isAccountNonExpired() {  // 만료되지 않은 계정
         return true;
     }
 
     @Override
-    public boolean isAccountNonLocked() {   // 계정 잠금
+    public boolean isAccountNonLocked() {
         return true;
     }
 
     @Override
-    public boolean isCredentialsNonExpired() {  // 자격 증명 만료
+    public boolean isCredentialsNonExpired() { // 자격 증명 유효조건
         return true;
     }
 
     @Override
-    public boolean isEnabled() {    // 로그인 가능한 계정인지
-        return true;
+    public boolean isEnabled() {
+        // 로그인 가능한 조건을 지정(승인 완료된 계정이어야만 로그인 가능)
+        return userVO.getUserStatus() == UserStatus.APPROVAL;
     }
 }

--- a/src/main/java/com/ssg/meowcoffee/service/CustomUserDetailsService.java
+++ b/src/main/java/com/ssg/meowcoffee/service/CustomUserDetailsService.java
@@ -19,7 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         UserVO userData = memberMapper.selectLoginUser(username);
         if (userData != null) {
-            // 여기에 마지막 로그인 날짜 갱신 로직 추가 필요
+            // 로그인 처리 완료 시 수행할 로직 - 해당 회
             memberMapper.updateLoginTime(userData.getUserId());
             return new CustomUserDetails(userData);
         }

--- a/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -10,8 +10,11 @@
        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
        http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd">
 
+    <!-- 스프링 시큐리티 관련 설정을 root context에 추가 -->
     <import resource="security-context.xml"/>
 
+    <!--  컨트롤러에서 요청을 처리하기 전에 스프링 시큐리티가 검증을 수행해야 하므로, root-context.xml에서 컨트롤러를 스캔하는 것을 방지해야 함 -->
+    <!--  (컨트롤러에 관한 컴포넌트 스캔 시, 컨트롤러에 관한 스프링 빈은 모두 서블릿 컨테이너에 등록되어야 함 -> servlet-context.xml 파일에만 컨트롤러 관련 설정이 포함되어야 함.)  -->
     <context:component-scan base-package="com.ssg.meowcoffee">
         <context:exclude-filter type="annotation" expression="org.springframework.stereotype.Controller"/>
     </context:component-scan>

--- a/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -10,11 +10,12 @@
        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
        http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd">
 
-    <!-- 스프링 시큐리티 관련 설정을 root context에 추가 -->
+    <!-- 설정이란 측면에서, security-context는 root context의 일부 -->
     <import resource="security-context.xml"/>
 
-    <!--  컨트롤러에서 요청을 처리하기 전에 스프링 시큐리티가 검증을 수행해야 하므로, root-context.xml에서 컨트롤러를 스캔하는 것을 방지해야 함 -->
-    <!--  (컨트롤러에 관한 컴포넌트 스캔 시, 컨트롤러에 관한 스프링 빈은 모두 서블릿 컨테이너에 등록되어야 함 -> servlet-context.xml 파일에만 컨트롤러 관련 설정이 포함되어야 함.)  -->
+    <!--  루트 컨텍스트에서는 웹 애플리케이션에서 공통으로 사용되는 서비스, mapper에 관한 스캔만 수행하고, -->
+    <!--  루트 컨텍스트의 자식 컨텍스트인 서블릿 컨텍스트(servlet-context)에서만 컨트롤러를 빈으로 등록하는 작업을 수행하도록 두 컨텍스트룰 분리 -->
+    <!--  (실행의 관점에서는 root-context와 servlet-context 사이에서 security-context가 실행될 수 있어야 함.)-->
     <context:component-scan base-package="com.ssg.meowcoffee">
         <context:exclude-filter type="annotation" expression="org.springframework.stereotype.Controller"/>
     </context:component-scan>

--- a/src/main/webapp/WEB-INF/spring/security-context.xml
+++ b/src/main/webapp/WEB-INF/spring/security-context.xml
@@ -8,33 +8,47 @@
   http://www.springframework.org/schema/beans
   http://www.springframework.org/schema/beans/spring-beans.xsd">
 
+  <!-- 회원등록/비밀번호 변경 시 사용자의 비밀번호를 암호화하기 위한 객체를 스프링 빈으로 등록 -->
   <bean id="bCryptPasswordEncoder" class="org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder"/>
 
+  <!-- 사용할 권한 간 위계 설정 -->
   <bean id="roleHierarchy" class="org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl">
     <property name="hierarchy">
       <value>
+        <!--  권한 간 위계: ADMIN > MANAGER > COMPANY, ADMIN > MANAGER > DELIVERYMAN -->
         ROLE_ADMIN > ROLE_MANAGER
         ROLE_MANAGER > ROLE_COMPANY
+        ROLE_MANAGER > ROLE_DELIVERYMAN
       </value>
     </property>
   </bean>
 
+  <!-- 설정한 위계를 반영한 권한을 웹 어플리케이션에 적용하기 위한 객체 -> 스프링 빈으로 등록 -->
   <bean id="webSecurityExpressionHandler" class="org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler">
     <property name="roleHierarchy" ref="roleHierarchy"/>
   </bean>
 
+  <!-- 사용자 로그인 시, 인증 작업을 진행할 커스텀 UserDetailsService 지정 -->
+  <!-- 이 프로젝트에서는 bCryptPasswordEncoder를 사용함 -->
   <security:authentication-manager>
+    <!--  인증에 사용할 비밀번호 암호화 수행 객체 등록  -->
     <security:authentication-provider user-service-ref="customUserDetailsService">
       <security:password-encoder ref="bCryptPasswordEncoder"/>
     </security:authentication-provider>
   </security:authentication-manager>
 
   <security:http>
-    <!--  권한별 접근 가능한 url 지정(현재는 테스트를 위해 별도 설정 없음)  -->
+    <!--  권한별 접근 가능한 url 지정(현재는 테스트를 위해 별도 설정 없음) -->
     <security:expression-handler ref="webSecurityExpressionHandler"/>
+
+    <!--  아래 태그를 이용하여 사용자 요청에 관한 인가를 진행 -->
+    <!--  스프링 시큐리티는 컨트롤러로 전달되는 요청을 먼저 가로채고, 사용자의 권한을 검사하여 해당 요청 처리 여부를 결정 -->
     <security:intercept-url pattern="/" access="permitAll()"/>
     <security:intercept-url pattern="/auth/**" access="permitAll()"/>
 <!--    <security:intercept-url pattern="/members/**" access="hasAnyRole('COMPANY')"/>-->
+
+<!--  로그인 시 사용할 url과 로그인 성공, 실패 시 출력할 url 지정,
+    사용자가 입력한 아이디, 비밀번호를 읽기 위한 파라미터의 이름 지정  -->
     <security:form-login
       login-page="/auth/login"
       login-processing-url="/auth/loginProcess"
@@ -42,12 +56,19 @@
       authentication-failure-url="/auth/login?error=true"
       username-parameter="userId"
       password-parameter="userPwd"/>
+
+<!--  로그아웃 요청 시 사용할 url과 로그아웃 성공 시 출력할 url 지정, 로그아웃 시 세션을 종료하도록 설정  -->
     <security:logout logout-url="/auth/logout" invalidate-session="true" logout-success-url="/auth/login?logout=true"/>
+
+<!--  로그인 세션에 관한 설정 추가: 세션 만료 시 출력할 url, 세션 갱신 방식 지정  -->
     <security:session-management
       invalid-session-url="/auth/login?sessionExpired=true"
       session-fixation-protection="changeSessionId">
+      <!--  동일 아이디로 중복 로그인 방지 -> 1개의 아이디당 1개의 세션만 사용 가능  -->
       <security:concurrency-control max-sessions="1" error-if-maximum-exceeded="true"/>
     </security:session-management>
+
+    <!--  csrf 방지 관련 설정 - 기능 테스트를 위해 해제한 상태  -->
     <security:csrf disabled="true"/>
   </security:http>
 

--- a/src/main/webapp/WEB-INF/spring/servlet-context.xml
+++ b/src/main/webapp/WEB-INF/spring/servlet-context.xml
@@ -11,6 +11,8 @@
     </bean>
 
     <!--  servlet-context.xml 파일에서는 컨트롤러 관련 설정만 추가  -->
+    <!--  이전에 servlet-context.xml 파일에 포함된 설정 클래스를 빈으로 등록하는 작업은 root-context에서 담당  -->
+    <!--  즉, 루트 컨테이너와 서블릿 컨테이너의 역할을 명확히 분리하고, 필터에 기반한 스프링 시큐리티 모듈이 그 사이에서 동작하는 구조가 되도록 설정해야 함   -->
     <context:component-scan base-package="com.ssg.meowcoffee.controller"/>
 
     <mvc:annotation-driven conversion-service="conversionService"/>


### PR DESCRIPTION
xml 파일에 추가된 스프링 시큐리티 관련 설정과, 로그인 기능을 구현할 때 사용한 스프링 시큐리티 제공 클래스에 관한 주석을 추가합니다.

그리고 제미나이와 공식 문서를 통해 추가적으로 찾아본 내용에 따르면, 컨트롤러 계층에서 현재 로그인한 사용자의 권한을 체크하기 위한 방법으로는 다음의 방법들이 있는 것 같습니다. 컨트롤러에서 사용자 권한에 따라 요청 가능한 URL을 제한해야 할 경우 참고하시면 좋을 것 같습니다.

방법1) UserDetails 객체에 저장된 사용자 정보 불러오기
: 컨트롤러의 파라미터로 UserDetails을 사용합니다. 이때, 컨트롤러 메서드의 파라미터로 사용된 UserDetails 앞에 `@AuthenticationPrincipal` 어노테이션을 사용합니다.

방법2) Authentication 객체에 저장된 사용자 정보를 불러오는 방법
: Authentication 객체가 제공하는 `getDetails()`, `getPrincipal()` 등의 메서드를 활용할 수 있습니다.
(관련 공식 문서 링크: https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/Authentication.html)

방법3) 컨트롤러 클래스의 메서드 자체에 `@PreAuthorize` 어노테이션을 사용하는 방법
: `@PreAuthorize("hasRole('ADMIN')")` 과 같은 방식으로 클래스의 메서드를 실행할 수 있는 권한을 지정하는 방법입니다.
(관련 공식 문서 링크(메서드 보안): https://docs.spring.io/spring-security/reference/servlet/authorization/method-security.html)