### PR TITLE
fix(member): 회원프로필 페이지 출력 오류 수정

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -11,7 +11,7 @@
             <AppenderRef ref="CONSOLE"/>
         </Logger>
 
-        <Logger name="com.ssg" level="INFO" additivity="false">
+        <Logger name="com.ssg" level="DEBUG" additivity="false">
             <AppenderRef ref="CONSOLE"/>
         </Logger>
 

--- a/src/main/webapp/WEB-INF/views/member/profile.jsp
+++ b/src/main/webapp/WEB-INF/views/member/profile.jsp
@@ -24,7 +24,7 @@
                                 <c:choose>
                                     <c:when test="${userRole == 'COMPANY'}">거래처 회원정보 조회</c:when>
                                     <c:when test="${userRole == 'MANAGER' || userRole == 'ADMIN'}">관리자 회원정보 조회</c:when>
-                                    <c:when test="${userRole == 'DELIVERY'}">배송기사 회원정보 조회</c:when>
+                                    <c:when test="${userRole == 'DELIVERYMAN'}">배송기사 회원정보 조회</c:when>
                                     <c:otherwise>회원정보 조회</c:otherwise>
                                 </c:choose>
                             </div>
@@ -219,7 +219,7 @@
                                     </c:if>
 
                                     <!-- 배송기사 전용 영역 -->
-                                    <c:if test="${userRole == 'DELIVERY'}">
+                                    <c:if test="${userRole == 'DELIVERYMAN'}">
                                         <div id="deliverySection">
                                             <label class="mb-3"><b>배송기사 확인 정보</b></label>
 

--- a/src/main/webapp/WEB-INF/views/member/profile.jsp
+++ b/src/main/webapp/WEB-INF/views/member/profile.jsp
@@ -8,8 +8,7 @@
 <c:set var="userId"   value="${userInfo.userId}" />
 
 <%-- 2) 그 다음에 header include --%>
-<%@ include file="/WEB-INF/views/includes/_headerHead.jsp" %>
-<%@ include file="/WEB-INF/views/includes/_headerNav.jsp" %>
+<%@ include file="/WEB-INF/views/includes/_header.jsp" %>
 
 <div class="container">
     <div class="page-inner">

--- a/src/main/webapp/WEB-INF/views/member/profile.jsp
+++ b/src/main/webapp/WEB-INF/views/member/profile.jsp
@@ -514,6 +514,7 @@
                 bootstrap.Modal
                     .getInstance(document.getElementById("dormantConfirmModal"))
                     .hide();
+                self.location = '/auth/logout';
             })
             .catch(err => {
                 console.error(err);


### PR DESCRIPTION
UserRole의 배송기사 enum 이름 변경으로 인해 회원프로필 페이지가 제대로 출력되지 않는 오류를 수정했습니다.
아울러 회원 프로필 페이지의 헤더 메뉴가 제대로 동작하지 않는 문제도 수정했습니다.

회원관리 기능 관련 README는 늦어도 다음주 주말까지는 작성해서 업로드하겠습니다.

