### PR TITLE
feat(auth): @AuthenticationPrinciple 어노테이션 오류 수정

### DIFF
--- a/src/main/java/com/ssg/meowcoffee/config/AuthenticationUserResolver.java
+++ b/src/main/java/com/ssg/meowcoffee/config/AuthenticationUserResolver.java
@@ -1,0 +1,51 @@
+package com.ssg.meowcoffee.config;
+
+import com.ssg.meowcoffee.dto.CustomUserDetails;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+// HandlerMethodArgumentResolver 인터페이스 구현
+public class AuthenticationUserResolver implements HandlerMethodArgumentResolver {
+
+    /**
+     * 해당 파라미터(인자)를 이 리졸버가 처리할지 여부를 결정합니다.
+     */
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        // 1. 파라미터에 @AuthenticationPrincipal 어노테이션이 붙어 있어야 하고,
+        boolean hasAnnotation = parameter.getParameterAnnotation(AuthenticationPrincipal.class) != null;
+        // 2. 파라미터의 타입이 CustomUserDetails 클래스여야 합니다.
+        boolean isCustomUserDetails = parameter.getParameterType().equals(CustomUserDetails.class);
+
+        return hasAnnotation && isCustomUserDetails;
+    }
+
+    /**
+     * 실제로 파라미터에 주입할 객체를 반환합니다.
+     */
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) throws Exception {
+
+        // ⭐️ AuthService에서 성공했던 핵심 로직을 사용합니다.
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails) {
+            // 메모리(SecurityContext)에 저장된, 이미 초기화된 유효한 객체를 반환합니다.
+            return authentication.getPrincipal();
+        }
+
+        // 인증되지 않은 경우나 타입 불일치 시 null 반환 (Spring이 알아서 처리)
+        return null;
+    }
+}

--- a/src/main/java/com/ssg/meowcoffee/controller/WarehouseController.java
+++ b/src/main/java/com/ssg/meowcoffee/controller/WarehouseController.java
@@ -40,7 +40,7 @@ public class WarehouseController {
         //일반관리자, 총관리자만 접근 가능
         String role = customUserDetails.getAuthorities().iterator().next().getAuthority();
 
-        if(!role.equals("ADMIN") && !role.equals("MANAGER")){
+        if(!role.equals("ROLE_ADMIN") && !role.equals("ROLE_MANAGER")){
             //권한 없음
             return ResponseEntity.ok(null);
         }

--- a/src/main/java/com/ssg/meowcoffee/dto/CustomUserDetails.java
+++ b/src/main/java/com/ssg/meowcoffee/dto/CustomUserDetails.java
@@ -7,7 +7,7 @@ import lombok.*;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.User;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -16,60 +16,37 @@ import java.util.List;
 
 @Log4j2
 @Getter
-@NoArgsConstructor
-public class CustomUserDetails implements UserDetails {
+public class CustomUserDetails extends User implements Serializable {
 
-    private String userId;
-    private String userPwd;
     private UserRole userRole;
     private UserStatus userStatus;
 
-    public CustomUserDetails(UserVO userVO) {
-        this.userId = userVO.getUserId();
-        this.userPwd = userVO.getUserPwd();
+    private CustomUserDetails(UserVO userVO) {
+        super(userVO.getUserId(),
+                userVO.getUserPwd(),
+                userVO.getUserStatus() == UserStatus.APPROVAL,  // 로그인 가능 조건
+                true,                                                   // 계정 유효조건
+                true,                                                   // 비밀번호 유효기간
+                userVO.getUserStatus() == UserStatus.APPROVAL,          // 계정 활성화 조건
+                createAuthorities(userVO.getUserRole())
+        );
         this.userRole = userVO.getUserRole();
         this.userStatus = userVO.getUserStatus();
     }
 
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
+    private static Collection<? extends GrantedAuthority> createAuthorities(UserRole userRole) {
         // 현재 로그인한 사용자가 보유한 권한을 반환
         List<GrantedAuthority> collection = new ArrayList<>();
-        collection.add(new SimpleGrantedAuthority("ROLE_" + this.userRole));
+        collection.add(new SimpleGrantedAuthority("ROLE_" + userRole.getRoleName()));
         return collection;
     }
 
-    @Override
-    public String getPassword() {
-        // 현재 로그인한 사용자의 비밀번호를 반환
-        return this.userPwd;
+    public static CustomUserDetails from(UserVO userVO) {
+        return new CustomUserDetails(userVO);
     }
 
-    @Override
-    public String getUsername() {
-        // 현재 로그인한 사용자의 아이디를 반환
-        return this.userId;
-    }
-
-    // 계정 만료, 잠금, 비밀번호 만료 관련 조건을 설정하는 부분
-    @Override
-    public boolean isAccountNonExpired() {  // 계정 만료조건
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {   // 계정 잠금 조건
-        return true;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() { // 비밀번호 만료조건
-        return true;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        // 로그인 가능한 조건을 지정(승인 완료된 계정이어야만 로그인 가능)
-        return this.userStatus == UserStatus.APPROVAL;
+    // 기존 코드 호환성 유지용 getter
+    public String getUserId() {
+        return super.getUsername();
     }
 }

--- a/src/main/java/com/ssg/meowcoffee/service/CustomUserDetailsService.java
+++ b/src/main/java/com/ssg/meowcoffee/service/CustomUserDetailsService.java
@@ -21,7 +21,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         if (userData != null) {
             // 로그인 처리 완료 시 수행할 로직
             memberMapper.updateLoginTime(userData.getUserId());
-            return new CustomUserDetails(userData);
+            return CustomUserDetails.from(userData);
         }
         throw new UsernameNotFoundException("사용자를 찾을 수 없습니다.");
     }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -7,7 +7,7 @@
 
     </Appenders>
     <Loggers>
-        <Logger name="org.springframework" level="INFO" additivity="false">
+        <Logger name="org.springframework" level="DEBUG" additivity="false">
             <AppenderRef ref="CONSOLE"/>
         </Logger>
 

--- a/src/main/webapp/WEB-INF/spring/servlet-context.xml
+++ b/src/main/webapp/WEB-INF/spring/servlet-context.xml
@@ -15,7 +15,20 @@
     <!--  즉, 루트 컨테이너와 서블릿 컨테이너의 역할을 명확히 분리하고, 필터에 기반한 스프링 시큐리티 모듈이 그 사이에서 동작하는 구조가 되도록 설정해야 함   -->
     <context:component-scan base-package="com.ssg.meowcoffee.controller"/>
 
-    <mvc:annotation-driven conversion-service="conversionService"/>
+    <!-- CustomUserDetails 객체의 복잡한 생성자 문제로 인해 Spring의 기본적인 주입 방식을 활용한 바인딩에 실패   -->
+    <!-- @AuthenticationPrinciple 어노테이션이 새로운 CustomUserDetails 객체를 만드는 것이 아닌, SecurityContext에 이미 저장된 로그인한 사용자 정보를 가져오게 만들어야 함   -->
+    <!-- 따라서 @AuthenticationPrinciple 어노테이션의 동작을 명시적으로 제어하기 위한 AuthenticationUserResolver 등록 필수   -->
+    <!-- 컴포넌트 스캔 대상으로 지정하지 않고 bean으로 직접 등록 -->
+    <bean id="authenticationUserResolver"
+          class="com.ssg.meowcoffee.config.AuthenticationUserResolver" />
+
+    <mvc:annotation-driven conversion-service="conversionService">
+        <!--    -->
+        <mvc:argument-resolvers>
+            <ref bean="authenticationUserResolver"/>
+        </mvc:argument-resolvers>
+    </mvc:annotation-driven>
+
     <mvc:resources mapping="/resources/**" location="classpath:/static/"/>
 
     <bean id="conversionService" class="org.springframework.format.support.FormattingConversionServiceFactoryBean">


### PR DESCRIPTION
@AuthenticationPrinciple 어노테이션을 컨트롤러 메서드의 파라미터에 사용했을 때, CustomUserDetails 객체를 새로 생성하는 대신 이미 로그인한 사용자에 관한 CustomUserDetails 객체를 가져오도록 커스텀 ArgumentResolver를 추가합니다.

창고/재고 관리 메뉴에서 테스트한 결과는 아래와 같습니다.

* 총관리자 아이디로 로그인 시

<img width="1909" height="954" alt="image" src="https://github.com/user-attachments/assets/b5323a1a-4751-428c-839f-fe2ce3c24558" />

* 거래처 아이디로 로그인 시

<img width="1917" height="901" alt="image" src="https://github.com/user-attachments/assets/93780f35-c961-4525-9a39-c627f99529fb" />
